### PR TITLE
Get current user's profile

### DIFF
--- a/src/main/java/wolox/training/controllers/ProfileController.java
+++ b/src/main/java/wolox/training/controllers/ProfileController.java
@@ -1,0 +1,31 @@
+package wolox.training.controllers;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wolox.training.exceptions.UserNotFoundException;
+import wolox.training.models.User;
+import wolox.training.repositories.UserRepository;
+
+@RestController
+@RequestMapping("/api/profile")
+@Api
+public class ProfileController {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @GetMapping
+    @ApiOperation(value = "Return the current user's profile")
+    public User getCurrentUserProfile() throws UserNotFoundException {
+        Authentication auth = SecurityContextHolder.getContext()
+            .getAuthentication();
+        return userRepository.findByUsername(auth.getName())
+            .orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/src/test/java/wolox/training/controllers/ProfileControllerTests.java
+++ b/src/test/java/wolox/training/controllers/ProfileControllerTests.java
@@ -1,0 +1,46 @@
+package wolox.training.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import wolox.training.factories.UserFactory;
+import wolox.training.models.User;
+import wolox.training.repositories.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ProfileControllerTests {
+
+    private final UserFactory userFactory = new UserFactory();
+
+    @Autowired
+    private MockMvc mvc;
+    @MockBean
+    private UserRepository userRepository;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(username = "test", password = "test")
+    public void whenUserIsLoggedIn_thenReturnUserInformation() throws Exception {
+        User user = userFactory.build();
+        String json = objectMapper.writeValueAsString(user);
+        Mockito.when(userRepository.findByUsername("test")).thenReturn(Optional.of(user));
+        mvc.perform(get("/api/profile").contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().json(json))
+        ;
+    }
+}

--- a/src/test/java/wolox/training/controllers/ProfileControllerTests.java
+++ b/src/test/java/wolox/training/controllers/ProfileControllerTests.java
@@ -43,4 +43,6 @@ public class ProfileControllerTests {
             .andExpect(content().json(json))
         ;
     }
+
+    ˇ
 }


### PR DESCRIPTION
## Summary

This adds an endpoint and test to get the current user's profile information.

## Trello Card

https://trello.com/c/UHfHEWaG/27-acceder-a-la-informaci%C3%B3n-del-user-logueado